### PR TITLE
PHP8.3 compatibility fixes

### DIFF
--- a/src/Classification/DecisionTree.php
+++ b/src/Classification/DecisionTree.php
@@ -386,9 +386,9 @@ class DecisionTree implements Classifier
                 $median = Mean::median($values);
                 foreach ($values as &$value) {
                     if ($value <= $median) {
-                        $value = "<= ${median}";
+                        $value = "<= {$median}";
                     } else {
-                        $value = "> ${median}";
+                        $value = "> {$median}";
                     }
                 }
             }

--- a/src/Classification/DecisionTree/DecisionTreeLeaf.php
+++ b/src/Classification/DecisionTree/DecisionTreeLeaf.php
@@ -122,7 +122,7 @@ class DecisionTreeLeaf
     public function getHTML(?array $columnNames = null): string
     {
         if ($this->isTerminal) {
-            $value = "<b>${this}->classValue</b>";
+            $value = "<b>{$this}->classValue</b>";
         } else {
             $value = $this->value;
             if ($columnNames !== null) {
@@ -132,13 +132,13 @@ class DecisionTreeLeaf
             }
 
             if ((bool) preg_match('/^[<>=]{1,2}/', (string) $value) === false) {
-                $value = "=${value}";
+                $value = "={$value}";
             }
 
-            $value = "<b>${col} ${value}</b><br>Gini: ".number_format($this->giniIndex, 2);
+            $value = "<b>{$col} {$value}</b><br>Gini: ".number_format($this->giniIndex, 2);
         }
 
-        $str = "<table ><tr><td colspan=3 align=center style='border:1px solid;'>${value}</td></tr>";
+        $str = "<table ><tr><td colspan=3 align=center style='border:1px solid;'>{$value}</td></tr>";
 
         if ($this->leftLeaf !== null || $this->rightLeaf !== null) {
             $str .= '<tr>';

--- a/src/Classification/Ensemble/RandomForest.php
+++ b/src/Classification/Ensemble/RandomForest.php
@@ -130,7 +130,7 @@ class RandomForest extends Bagging
     {
         if (!$classifier instanceof DecisionTree) {
             throw new InvalidArgumentException(
-                sprintf('Classifier %s expected, got %s', DecisionTree::class, get_class($classifier))
+                sprintf('Classifier %s expected, got %s', DecisionTree::class, $classifier::class)
             );
         }
 

--- a/src/Classification/Linear/DecisionStump.php
+++ b/src/Classification/Linear/DecisionStump.php
@@ -87,7 +87,7 @@ class DecisionStump extends WeightedClassifier
 
     public function __toString(): string
     {
-        return "IF ${this}->column ${this}->operator ${this}->value ".
+        return "IF {$this}->column {$this}->operator {$this}->value ".
             'THEN '.$this->binaryLabels[0].' '.
             'ELSE '.$this->binaryLabels[1];
     }

--- a/src/FeatureExtraction/StopWords.php
+++ b/src/FeatureExtraction/StopWords.php
@@ -25,7 +25,7 @@ class StopWords
 
     public static function factory(string $language = 'English'): self
     {
-        $className = __NAMESPACE__."\\StopWords\\${language}";
+        $className = __NAMESPACE__."\\StopWords\\{$language}";
 
         if (!class_exists($className)) {
             throw new InvalidArgumentException(sprintf('Can\'t find "%s" language for StopWords', $language));

--- a/src/Helper/OneVsRest.php
+++ b/src/Helper/OneVsRest.php
@@ -157,7 +157,7 @@ trait OneVsRest
      */
     private function binarizeTargets(array $targets, $label): array
     {
-        $notLabel = "not_${label}";
+        $notLabel = "not_{$label}";
         foreach ($targets as $key => $target) {
             $targets[$key] = $target == $label ? $label : $notLabel;
         }

--- a/tests/Association/AprioriTest.php
+++ b/tests/Association/AprioriTest.php
@@ -272,7 +272,7 @@ class AprioriTest extends TestCase
      */
     private static function invoke(Apriori $object, string $method, array $params = [])
     {
-        $reflection = new ReflectionClass(get_class($object));
+        $reflection = new ReflectionClass($object::class);
         $method = $reflection->getMethod($method);
         $method->setAccessible(true);
 

--- a/tests/Dataset/CsvDatasetTest.php
+++ b/tests/Dataset/CsvDatasetTest.php
@@ -18,7 +18,7 @@ class CsvDatasetTest extends TestCase
 
     public function testSampleCsvDatasetWithHeaderRow(): void
     {
-        $filePath = dirname(__FILE__).'/Resources/dataset.csv';
+        $filePath = __DIR__.'/Resources/dataset.csv';
 
         $dataset = new CsvDataset($filePath, 2, true);
 
@@ -28,7 +28,7 @@ class CsvDatasetTest extends TestCase
 
     public function testSampleCsvDatasetWithoutHeaderRow(): void
     {
-        $filePath = dirname(__FILE__).'/Resources/dataset.csv';
+        $filePath = __DIR__.'/Resources/dataset.csv';
 
         $dataset = new CsvDataset($filePath, 2, false);
 
@@ -38,7 +38,7 @@ class CsvDatasetTest extends TestCase
 
     public function testLongCsvDataset(): void
     {
-        $filePath = dirname(__FILE__).'/Resources/longdataset.csv';
+        $filePath = __DIR__.'/Resources/longdataset.csv';
 
         $dataset = new CsvDataset($filePath, 1000, false);
 

--- a/tests/Dataset/FilesDatasetTest.php
+++ b/tests/Dataset/FilesDatasetTest.php
@@ -18,7 +18,7 @@ class FilesDatasetTest extends TestCase
 
     public function testLoadFilesDatasetWithBBCData(): void
     {
-        $rootPath = dirname(__FILE__).'/Resources/bbc';
+        $rootPath = __DIR__.'/Resources/bbc';
 
         $dataset = new FilesDataset($rootPath);
 


### PR DESCRIPTION
fixes https://github.com/coral-media/php-ml/issues/3

this was fixed automatically with [Rector](https://github.com/rectorphp/rector) using the config 
```php
<?php

declare(strict_types=1);

return (static function (\Rector\Config\RectorConfig $rectorConfig): void {
    $rectorConfig->paths([
        '/home/hans/projects/php-ml/',
    ]);
    $rectorConfig->sets([
        //\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_82,
        \Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_83,
    ]);
    $rectorConfig->skip([
        Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector::class,
        \Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector::class,
        \Rector\Php80\Rector\FunctionLike\MixedTypeRector::class,
        \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
        \Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector::class,
        \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
        \Rector\Php80\Rector\Class_\StringableForToStringRector::class,
        \Rector\Php70\Rector\FuncCall\RandomFunctionRector::class,
        \Rector\Php83\Rector\ClassConst\AddTypeToConstRector::class,
        \Rector\Php81\Rector\ClassMethod\NewInInitializerRector::class,
    ]);
});
```

as for why i disabled many of the rules: many of them are just personal-preference changes, and some of them break php7.4 compatibility, and none of the disabled ones are required for php8.3 compatibility. 