### PR TITLE
feat (docker): replace openjdk11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     php:
-        platform: linux/x86_64
+        platform: linux/amd64
         container_name: coral-media-php-ml
         build:
             context: .

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.2-fpm-alpine
 
 RUN apk update
 RUN apk add --no-cache git fcgi perl wget procps shadow libzip \
-    openssh freetype zip htop openjdk11
+    openssh freetype zip htop openjdk11-jre
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer

--- a/src/Clustering/XMeans.php
+++ b/src/Clustering/XMeans.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Phpml\Clustering;
+
+class XMeans {
+
+}


### PR DESCRIPTION
- Replaced `openjdk11` with the `openjdk11-jre`, only the JRE it's required to run SVM classes

Refs: #19